### PR TITLE
fix typo and format README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 ## MLTD日服榜線抓取以及圖片產生器
+
 所有榜線資訊都由api.matsurihi.me提供
   
-  
 ## 使用方法
-使用argparse格式，在terminal中輸入：`python main.py -t [*choices]`  
+
+使用argparse格式，在terminal中輸入：`python main.py -t [choices]`  
 
 ## 說明
+
 `choices` 為榜線類型，提供了pt榜("pt")、高分榜("hs")、廳榜("lp")  
-`choicse` 為 `*kargs` 格式，提供一次輸入多種榜線類型，能夠一次輸出三種榜線圖片
+`choices` 為 `*args` 格式，提供一次輸入多種榜線類型，能夠一次輸出三種榜線圖片


### PR DESCRIPTION
根據vscode的`davidanson.vscode-markdownlint` extension進行format  
然後`kargs`是dict，這裡應該要用`args`  
第7行的星號我覺得可不加  
